### PR TITLE
[#2]: auto-assign 설정

### DIFF
--- a/.github/auto-assign.yml
+++ b/.github/auto-assign.yml
@@ -1,0 +1,20 @@
+# Set to true to add reviewers to pull requests
+addReviewers: true
+
+# Set to true to add assignees to pull requests
+addAssignees: true
+
+# A list of reviewers to be added to pull requests (GitHub user name)
+reviewers:
+  - moondalnim
+  - HimHeys
+  - jdyj
+  - akrudal
+
+# A list of keywords to be skipped the process that add reviewers if pull requests include it 
+skipKeywords:
+  - wip
+
+# A number of reviewers added to the pull request
+# Set 0 to add all the reviewers (default: 0)
+numberOfReviewers: 0


### PR DESCRIPTION
## 설명
깃허브에서 pull request 생성시 Reviewers와 Assignees를 직접 설정 해줘야 하는 불편함이 잇습니다.
이를 해결하기 위해 Git App인 [auto-assign](https://github.com/apps/auto-assign)을 적용하였습니다.

## 작업 내용
setting에 [branch 설정](https://github.com/MoyeoRun/MoyeoRun_iOS/settings/branch_protection_rules/24849062)을 보시면 2명 이상의 리뷰어가 승인을 했을시에 pr을 머지할 수 있도록 설정하였습니다.
auto-assign 설정을 위해 MoyeoRun_iOS 저장소에 auto-assign앱을 추가하였습니다.
해당 기능의 설정과 유저 닉네임이 기록된 .github/.auto-assign.yml을 추가하였습니다.

## 전달 사항
해당 기능이 머지가 되면 따로 Reviewers나 Assignees를 설정 안해도 됩니다.
chore라는 라벨이 Commitizen에 없을텐데 원본 Conventional Commits에서는 있습니다.
설정과 같은 귀찮은 작업에 대한 타입으로 설명하고 있기에 마땅한 태그가 없어 추가했습니다.

## 작업 환경
macOS: Monterey 12.2.1
iOS: 기기 미사용

Resolves: #2