### PR TITLE
[#37]: 사용자 위치 권한 설정 추가

### DIFF
--- a/MoyeoRun/Info.plist
+++ b/MoyeoRun/Info.plist
@@ -21,5 +21,7 @@
 			</array>
 		</dict>
 	</dict>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string>사용자의 위치 정보를 받으려고 합니다.</string>
 </dict>
 </plist>


### PR DESCRIPTION
## 설명
사용자 위치 권한 설정 추가

## 작업 내용
Info.plist 수정

## 전달 사항
Privacy - Location Always and When In Use Usage Description 의 Value를 논의해봐야 할 것 같습니다.
현재는 "사용자의 위치 정보를 받으려고 합니다."로 설정 해놓았습니다.

## 작업 환경
macOS: 12.1
iOS: 기기 미사용

Closes: #37 
