### PR TITLE
[#34] 로그인 14 페이지, 프로필 이미지 터치와 연결 완료

### DIFF
--- a/MoyeoRun.xcodeproj/project.pbxproj
+++ b/MoyeoRun.xcodeproj/project.pbxproj
@@ -22,6 +22,8 @@
 		0A95B92927F3563100E131E6 /* HomeTabNowPopularContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A95B92827F3563100E131E6 /* HomeTabNowPopularContainer.swift */; };
 		0A95B92B27F3564300E131E6 /* HomeTabNewMissionContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A95B92A27F3564300E131E6 /* HomeTabNewMissionContainer.swift */; };
 		0A95B92D27F3565300E131E6 /* HomeTabLastRecordContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A95B92C27F3565300E131E6 /* HomeTabLastRecordContainer.swift */; };
+		0AB1028427F7474200030C06 /* MyPage.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 0AB1028327F7474200030C06 /* MyPage.storyboard */; };
+		0AB1028727F747DA00030C06 /* MyPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AB1028627F747DA00030C06 /* MyPageViewController.swift */; };
 		0AF2314327F0650000574776 /* HomeTabNowPopular0.png in Resources */ = {isa = PBXBuildFile; fileRef = 0AF2314027F0650000574776 /* HomeTabNowPopular0.png */; };
 		0AF2314427F0650000574776 /* HomeTabNowPopular1.png in Resources */ = {isa = PBXBuildFile; fileRef = 0AF2314127F0650000574776 /* HomeTabNowPopular1.png */; };
 		0AF2314527F0650000574776 /* HomeTabNowPopular2.png in Resources */ = {isa = PBXBuildFile; fileRef = 0AF2314227F0650000574776 /* HomeTabNowPopular2.png */; };
@@ -58,6 +60,8 @@
 		0A95B92827F3563100E131E6 /* HomeTabNowPopularContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeTabNowPopularContainer.swift; sourceTree = "<group>"; };
 		0A95B92A27F3564300E131E6 /* HomeTabNewMissionContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeTabNewMissionContainer.swift; sourceTree = "<group>"; };
 		0A95B92C27F3565300E131E6 /* HomeTabLastRecordContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeTabLastRecordContainer.swift; sourceTree = "<group>"; };
+		0AB1028327F7474200030C06 /* MyPage.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = MyPage.storyboard; sourceTree = "<group>"; };
+		0AB1028627F747DA00030C06 /* MyPageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageViewController.swift; sourceTree = "<group>"; };
 		0AF2314027F0650000574776 /* HomeTabNowPopular0.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = HomeTabNowPopular0.png; sourceTree = "<group>"; };
 		0AF2314127F0650000574776 /* HomeTabNowPopular1.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = HomeTabNowPopular1.png; sourceTree = "<group>"; };
 		0AF2314227F0650000574776 /* HomeTabNowPopular2.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = HomeTabNowPopular2.png; sourceTree = "<group>"; };
@@ -195,6 +199,39 @@
 			path = HomeTabContainers;
 			sourceTree = "<group>";
 		};
+		0AB1028027F746D800030C06 /* MyPage */ = {
+			isa = PBXGroup;
+			children = (
+				0AB1028527F7475300030C06 /* ViewControllers */,
+				0AB1028127F746E300030C06 /* Views */,
+			);
+			path = MyPage;
+			sourceTree = "<group>";
+		};
+		0AB1028127F746E300030C06 /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				0AB1028227F746F200030C06 /* InterfaceBuilders */,
+			);
+			path = Views;
+			sourceTree = "<group>";
+		};
+		0AB1028227F746F200030C06 /* InterfaceBuilders */ = {
+			isa = PBXGroup;
+			children = (
+				0AB1028327F7474200030C06 /* MyPage.storyboard */,
+			);
+			path = InterfaceBuilders;
+			sourceTree = "<group>";
+		};
+		0AB1028527F7475300030C06 /* ViewControllers */ = {
+			isa = PBXGroup;
+			children = (
+				0AB1028627F747DA00030C06 /* MyPageViewController.swift */,
+			);
+			path = ViewControllers;
+			sourceTree = "<group>";
+		};
 		0AF2313F27F064E200574776 /* HomeTab */ = {
 			isa = PBXGroup;
 			children = (
@@ -214,6 +251,7 @@
 		3AADB25227EF53ED00AFDE01 /* Scenes */ = {
 			isa = PBXGroup;
 			children = (
+				0AB1028027F746D800030C06 /* MyPage */,
 				0A8DE82427F0489C00077DC6 /* TabBar */,
 				0A8DE82C27F04D9A00077DC6 /* HomeTab */,
 				3AADB25627EF552F00AFDE01 /* Login */,
@@ -425,6 +463,7 @@
 				F75E9FA927E9470200000DCD /* LaunchScreen.storyboard in Resources */,
 				0AF2314527F0650000574776 /* HomeTabNowPopular2.png in Resources */,
 				0A8DE83127F04DEC00077DC6 /* HomeTab.storyboard in Resources */,
+				0AB1028427F7474200030C06 /* MyPage.storyboard in Resources */,
 				F75E9FA627E9470200000DCD /* Assets.xcassets in Resources */,
 				0AF2314F27F0650B00574776 /* HomeTabNewMission3.png in Resources */,
 				0A8DE83827F0517700077DC6 /* 참가자.png in Resources */,
@@ -495,6 +534,7 @@
 				0A95B92B27F3564300E131E6 /* HomeTabNewMissionContainer.swift in Sources */,
 				0A95B92927F3563100E131E6 /* HomeTabNowPopularContainer.swift in Sources */,
 				F75E9F9C27E9470100000DCD /* SceneDelegate.swift in Sources */,
+				0AB1028727F747DA00030C06 /* MyPageViewController.swift in Sources */,
 				0A8DE84027F052C000077DC6 /* HomeTabViewController.swift in Sources */,
 				F75E9FA427E9470100000DCD /* MoyeoRun.xcdatamodeld in Sources */,
 				0A8DE83327F04EB100077DC6 /* TabBarViewController.swift in Sources */,

--- a/MoyeoRun/Scenes/HomeTab/ViewControllers/HomeTabViewController.swift
+++ b/MoyeoRun/Scenes/HomeTab/ViewControllers/HomeTabViewController.swift
@@ -24,13 +24,8 @@ class HomeTabViewController: UIViewController {
     }
 
     func setUI() {
-        setProfileImageView()
         setHeightConstraint()
-    }
-
-    func setProfileImageView() {
-        self.profileImageView.layer.cornerRadius = self.profileImageView.frame.width / 2
-        self.profileImageView.layer.masksToBounds = true
+        setProfileImageView()
     }
 
     func setHeightConstraint() {
@@ -39,5 +34,23 @@ class HomeTabViewController: UIViewController {
         scrollViewHeightConstraint.constant = screenHeightForSetting + fixedHeight
         nowPopularContainerHeightConstraint.constant = screenHeightForSetting * 0.25
         newMissionContainerHeightConstraint.constant = screenHeightForSetting * 0.5 + 110
+    }
+
+    func setProfileImageView() {
+        self.profileImageView.layer.cornerRadius = self.profileImageView.frame.width / 2
+        self.profileImageView.layer.masksToBounds = true
+
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(self.showMyPage))
+        profileImageView.isUserInteractionEnabled = true
+        profileImageView.addGestureRecognizer(tapGesture)
+    }
+
+    @objc func showMyPage(sender: UITapGestureRecognizer) {
+        if sender.state == .ended {
+            let storyBoard = UIStoryboard(name: "MyPage", bundle: nil)
+            let viewController = storyBoard.instantiateViewController(withIdentifier: "MyPage")
+            viewController.modalPresentationStyle = .fullScreen
+            self.present(viewController, animated: true)
+        }
     }
 }

--- a/MoyeoRun/Scenes/MakeRoom/Views/InterfaceBuilders/MakeRoom.storyboard
+++ b/MoyeoRun/Scenes/MakeRoom/Views/InterfaceBuilders/MakeRoom.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -12,7 +12,7 @@
         <!--Make Room Controller-->
         <scene sceneID="B80-ES-wuo">
             <objects>
-                <viewController storyboardIdentifier="makeRoomController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="T6h-sA-HDN" customClass="MakeRoomController" customModule="Moyeorun" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="makeRoomController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="T6h-sA-HDN" customClass="MakeRoomController" customModule="MoyeoRun" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="7oi-ZR-nmM">
                         <rect key="frame" x="0.0" y="0.0" width="390" height="998"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -259,7 +259,7 @@
         <!--Popup View Controller-->
         <scene sceneID="upl-wA-ppI">
             <objects>
-                <viewController storyboardIdentifier="PopupViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="vtf-Ew-8yX" customClass="PopupViewController" customModule="Moyeorun" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="PopupViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="vtf-Ew-8yX" customClass="PopupViewController" customModule="MoyeoRun" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" opaque="NO" contentMode="scaleToFill" id="SqR-rC-AHY">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/MoyeoRun/Scenes/MyPage/ViewControllers/MyPageViewController.swift
+++ b/MoyeoRun/Scenes/MyPage/ViewControllers/MyPageViewController.swift
@@ -1,0 +1,27 @@
+//
+//  MyPageViewController.swift
+//  MoyeoRun
+//
+//  Created by 김상현 on 2022/04/01.
+//
+
+import UIKit
+
+class MyPageViewController: UIViewController {
+    @IBOutlet weak var profileImageView: UIImageView!
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setUI()
+    }
+
+    func setUI() {
+        setProfileImageView()
+    }
+
+    func setProfileImageView() {
+        self.profileImageView.layer.cornerRadius = self.profileImageView.frame.width / 2
+        self.profileImageView.layer.masksToBounds = true
+        self.profileImageView.layer.borderWidth = 0
+    }
+}

--- a/MoyeoRun/Scenes/MyPage/Views/InterfaceBuilders/MyPage.storyboard
+++ b/MoyeoRun/Scenes/MyPage/Views/InterfaceBuilders/MyPage.storyboard
@@ -18,13 +18,14 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="프로필 이미지.png" translatesAutoresizingMaskIntoConstraints="NO" id="edo-za-nqt">
-                                <rect key="frame" x="165.5" y="90.5" width="83" height="83"/>
+                                <rect key="frame" x="177" y="90.5" width="60" height="60"/>
                                 <constraints>
                                     <constraint firstAttribute="width" secondItem="edo-za-nqt" secondAttribute="height" id="eNd-mj-h4M"/>
+                                    <constraint firstAttribute="width" constant="60" id="gYU-To-irb"/>
                                 </constraints>
                             </imageView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="8oi-fD-wmx">
-                                <rect key="frame" x="168" y="183.5" width="78" height="78.5"/>
+                                <rect key="frame" x="168" y="160.5" width="78" height="78.5"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="박주영" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="39v-LW-8hV">
                                         <rect key="frame" x="10.5" y="0.0" width="57.5" height="26.5"/>
@@ -46,8 +47,8 @@
                                     </label>
                                 </subviews>
                             </stackView>
-                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="center" spacing="50" translatesAutoresizingMaskIntoConstraints="NO" id="x7l-9l-OoT">
-                                <rect key="frame" x="20.5" y="282" width="373" height="250"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="center" spacing="40" translatesAutoresizingMaskIntoConstraints="NO" id="x7l-9l-OoT">
+                                <rect key="frame" x="20.5" y="259" width="373" height="230"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="68X-DI-kxW">
                                         <rect key="frame" x="0.0" y="0.0" width="373" height="50"/>
@@ -77,7 +78,7 @@
                                         </userDefinedRuntimeAttributes>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bTP-rv-GqQ">
-                                        <rect key="frame" x="0.0" y="100" width="373" height="50"/>
+                                        <rect key="frame" x="0.0" y="90" width="373" height="50"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="50" id="aPt-wJ-Jbg"/>
                                         </constraints>
@@ -104,7 +105,7 @@
                                         </userDefinedRuntimeAttributes>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="jLr-IX-2hu">
-                                        <rect key="frame" x="0.0" y="200" width="373" height="50"/>
+                                        <rect key="frame" x="0.0" y="180" width="373" height="50"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="50" id="uzS-GT-NRD"/>
                                         </constraints>
@@ -145,7 +146,6 @@
                             <constraint firstItem="edo-za-nqt" firstAttribute="centerX" secondItem="lft-7j-YdU" secondAttribute="centerX" id="JMP-p0-Eft"/>
                             <constraint firstItem="x7l-9l-OoT" firstAttribute="top" secondItem="8oi-fD-wmx" secondAttribute="bottom" constant="20" id="Kzl-bZ-cBS"/>
                             <constraint firstItem="x7l-9l-OoT" firstAttribute="width" secondItem="x1E-sV-Low" secondAttribute="width" multiplier="0.9" id="NCw-Ag-tc7"/>
-                            <constraint firstItem="edo-za-nqt" firstAttribute="width" secondItem="x1E-sV-Low" secondAttribute="width" multiplier="0.2" id="NLX-Fq-msQ"/>
                             <constraint firstItem="8oi-fD-wmx" firstAttribute="centerX" secondItem="lft-7j-YdU" secondAttribute="centerX" id="QsN-i3-RMg"/>
                             <constraint firstItem="edo-za-nqt" firstAttribute="top" secondItem="lft-7j-YdU" secondAttribute="centerY" multiplier="0.2" id="kM9-lq-1Ef"/>
                             <constraint firstItem="8oi-fD-wmx" firstAttribute="top" secondItem="edo-za-nqt" secondAttribute="bottom" constant="10" id="oVa-Cz-Byp"/>
@@ -157,7 +157,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="3Dm-Y1-2cP" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="255" y="55"/>
+            <point key="canvasLocation" x="-214" y="21"/>
         </scene>
     </scenes>
     <resources>

--- a/MoyeoRun/Scenes/MyPage/Views/InterfaceBuilders/MyPage.storyboard
+++ b/MoyeoRun/Scenes/MyPage/Views/InterfaceBuilders/MyPage.storyboard
@@ -1,0 +1,169 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="8a2-Aq-f7e">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--My Page View Controller-->
+        <scene sceneID="AJP-Uy-mcj">
+            <objects>
+                <viewController storyboardIdentifier="MyPage" id="8a2-Aq-f7e" customClass="MyPageViewController" customModule="MoyeoRun" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="x1E-sV-Low">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="프로필 이미지.png" translatesAutoresizingMaskIntoConstraints="NO" id="edo-za-nqt">
+                                <rect key="frame" x="165.5" y="90.5" width="83" height="83"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" secondItem="edo-za-nqt" secondAttribute="height" id="eNd-mj-h4M"/>
+                                </constraints>
+                            </imageView>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="8oi-fD-wmx">
+                                <rect key="frame" x="168" y="183.5" width="78" height="78.5"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="박주영" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="39v-LW-8hV">
+                                        <rect key="frame" x="10.5" y="0.0" width="57.5" height="26.5"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="22"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="kuhy3710" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Nxe-ck-bVI">
+                                        <rect key="frame" x="0.0" y="34.5" width="78" height="21.5"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="18"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="170cm 65kg" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sBH-am-CUQ">
+                                        <rect key="frame" x="4.5" y="64" width="69" height="14.5"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                        <color key="textColor" red="0.73725490199999999" green="0.73725490199999999" blue="0.73725490199999999" alpha="1" colorSpace="calibratedRGB"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                            </stackView>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="center" spacing="50" translatesAutoresizingMaskIntoConstraints="NO" id="x7l-9l-OoT">
+                                <rect key="frame" x="20.5" y="282" width="373" height="250"/>
+                                <subviews>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="68X-DI-kxW">
+                                        <rect key="frame" x="0.0" y="0.0" width="373" height="50"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="50" id="Q97-gT-30y"/>
+                                        </constraints>
+                                        <state key="normal" title="Button"/>
+                                        <buttonConfiguration key="configuration" style="plain">
+                                            <attributedString key="attributedTitle">
+                                                <fragment content="프로필 편집">
+                                                    <attributes>
+                                                        <font key="NSFont" size="18" name="AppleSDGothicNeo-Regular"/>
+                                                    </attributes>
+                                                </fragment>
+                                            </attributedString>
+                                        </buttonConfiguration>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="number" keyPath="borderWidth">
+                                                <real key="value" value="1"/>
+                                            </userDefinedRuntimeAttribute>
+                                            <userDefinedRuntimeAttribute type="color" keyPath="borderColor">
+                                                <color key="value" red="0.83137254900000002" green="0.83137254900000002" blue="0.83137254900000002" alpha="0.80000001190000003" colorSpace="custom" customColorSpace="sRGB"/>
+                                            </userDefinedRuntimeAttribute>
+                                            <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                                                <real key="value" value="4"/>
+                                            </userDefinedRuntimeAttribute>
+                                        </userDefinedRuntimeAttributes>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bTP-rv-GqQ">
+                                        <rect key="frame" x="0.0" y="100" width="373" height="50"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="50" id="aPt-wJ-Jbg"/>
+                                        </constraints>
+                                        <state key="normal" title="Button"/>
+                                        <buttonConfiguration key="configuration" style="plain">
+                                            <attributedString key="attributedTitle">
+                                                <fragment content="알람 설정">
+                                                    <attributes>
+                                                        <font key="NSFont" size="18" name="AppleSDGothicNeo-Regular"/>
+                                                    </attributes>
+                                                </fragment>
+                                            </attributedString>
+                                        </buttonConfiguration>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="number" keyPath="borderWidth">
+                                                <real key="value" value="1"/>
+                                            </userDefinedRuntimeAttribute>
+                                            <userDefinedRuntimeAttribute type="color" keyPath="borderColor">
+                                                <color key="value" red="0.83137254900000002" green="0.83137254900000002" blue="0.83137254900000002" alpha="1" colorSpace="calibratedRGB"/>
+                                            </userDefinedRuntimeAttribute>
+                                            <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                                                <real key="value" value="4"/>
+                                            </userDefinedRuntimeAttribute>
+                                        </userDefinedRuntimeAttributes>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="jLr-IX-2hu">
+                                        <rect key="frame" x="0.0" y="200" width="373" height="50"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="50" id="uzS-GT-NRD"/>
+                                        </constraints>
+                                        <state key="normal" title="Button"/>
+                                        <buttonConfiguration key="configuration" style="plain">
+                                            <attributedString key="attributedTitle">
+                                                <fragment content="로그아웃">
+                                                    <attributes>
+                                                        <font key="NSFont" size="18" name="AppleSDGothicNeo-Regular"/>
+                                                    </attributes>
+                                                </fragment>
+                                            </attributedString>
+                                        </buttonConfiguration>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="number" keyPath="borderWidth">
+                                                <real key="value" value="1"/>
+                                            </userDefinedRuntimeAttribute>
+                                            <userDefinedRuntimeAttribute type="color" keyPath="borderColor">
+                                                <color key="value" red="0.83137254900000002" green="0.83137254900000002" blue="0.83137254900000002" alpha="1" colorSpace="calibratedRGB"/>
+                                            </userDefinedRuntimeAttribute>
+                                            <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                                                <real key="value" value="4"/>
+                                            </userDefinedRuntimeAttribute>
+                                        </userDefinedRuntimeAttributes>
+                                    </button>
+                                </subviews>
+                                <constraints>
+                                    <constraint firstItem="68X-DI-kxW" firstAttribute="width" secondItem="x7l-9l-OoT" secondAttribute="width" id="gwn-XX-O1b"/>
+                                    <constraint firstItem="jLr-IX-2hu" firstAttribute="width" secondItem="x7l-9l-OoT" secondAttribute="width" id="oCn-kf-16q"/>
+                                    <constraint firstItem="bTP-rv-GqQ" firstAttribute="width" secondItem="x7l-9l-OoT" secondAttribute="width" id="xIf-GZ-Yqz"/>
+                                </constraints>
+                            </stackView>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="lft-7j-YdU"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="x7l-9l-OoT" firstAttribute="centerX" secondItem="lft-7j-YdU" secondAttribute="centerX" id="H85-FC-wd0"/>
+                            <constraint firstItem="edo-za-nqt" firstAttribute="centerX" secondItem="lft-7j-YdU" secondAttribute="centerX" id="JMP-p0-Eft"/>
+                            <constraint firstItem="x7l-9l-OoT" firstAttribute="top" secondItem="8oi-fD-wmx" secondAttribute="bottom" constant="20" id="Kzl-bZ-cBS"/>
+                            <constraint firstItem="x7l-9l-OoT" firstAttribute="width" secondItem="x1E-sV-Low" secondAttribute="width" multiplier="0.9" id="NCw-Ag-tc7"/>
+                            <constraint firstItem="edo-za-nqt" firstAttribute="width" secondItem="x1E-sV-Low" secondAttribute="width" multiplier="0.2" id="NLX-Fq-msQ"/>
+                            <constraint firstItem="8oi-fD-wmx" firstAttribute="centerX" secondItem="lft-7j-YdU" secondAttribute="centerX" id="QsN-i3-RMg"/>
+                            <constraint firstItem="edo-za-nqt" firstAttribute="top" secondItem="lft-7j-YdU" secondAttribute="centerY" multiplier="0.2" id="kM9-lq-1Ef"/>
+                            <constraint firstItem="8oi-fD-wmx" firstAttribute="top" secondItem="edo-za-nqt" secondAttribute="bottom" constant="10" id="oVa-Cz-Byp"/>
+                        </constraints>
+                    </view>
+                    <connections>
+                        <outlet property="profileImageView" destination="edo-za-nqt" id="sIE-Di-72T"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="3Dm-Y1-2cP" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="255" y="55"/>
+        </scene>
+    </scenes>
+    <resources>
+        <image name="프로필 이미지.png" width="123" height="123"/>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>


### PR DESCRIPTION
## 설명
피그마 로그인 14 페이지 뷰 작업 완료, 프로필 이미지 터치와 연결 완료.

## 작업 내용
피그마 상에서 로그인 14 페이지의 스토리보드와 뷰 컨트롤러를 만들었습니다. 또 홈 탭에서 프로필 이미지를 터치하여 해당 뷰로 이동할 수 있도록 연결해두었습니다.

## 전달 사항
PR '[#34] MyPage 작업 (Figma: 로그인 14)' 와 커밋 내용은 그대로입니다. 다만, 브랜치명을 수정하였습니다.

## 작업 환경
macOS: 12.1
iOS: 

Closes: #34 
