### PR TITLE
[#43]: 디렉토리 인식 오류 해결

### DIFF
--- a/MoyeoRun.xcodeproj/project.pbxproj
+++ b/MoyeoRun.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0A26EDD4280AD19C0077C042 /* MyPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A26EDD3280AD19C0077C042 /* MyPageViewController.swift */; };
+		0A26EDD7280AD1B10077C042 /* MyPage.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 0A26EDD6280AD1B10077C042 /* MyPage.storyboard */; };
 		0A8DE82B27F04CC900077DC6 /* TabBar.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 0A8DE82A27F04CC900077DC6 /* TabBar.storyboard */; };
 		0A8DE83127F04DEC00077DC6 /* HomeTab.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 0A8DE83027F04DEC00077DC6 /* HomeTab.storyboard */; };
 		0A8DE83327F04EB100077DC6 /* TabBarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A8DE83227F04EB100077DC6 /* TabBarViewController.swift */; };
@@ -44,6 +46,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		0A26EDD3280AD19C0077C042 /* MyPageViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MyPageViewController.swift; sourceTree = "<group>"; };
+		0A26EDD6280AD1B10077C042 /* MyPage.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = MyPage.storyboard; sourceTree = "<group>"; };
 		0A8DE82A27F04CC900077DC6 /* TabBar.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = TabBar.storyboard; sourceTree = "<group>"; };
 		0A8DE83027F04DEC00077DC6 /* HomeTab.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = HomeTab.storyboard; sourceTree = "<group>"; };
 		0A8DE83227F04EB100077DC6 /* TabBarViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarViewController.swift; sourceTree = "<group>"; };
@@ -96,6 +100,39 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		0A26EDD0280AD1800077C042 /* MyPage */ = {
+			isa = PBXGroup;
+			children = (
+				0A26EDD2280AD18F0077C042 /* Views */,
+				0A26EDD1280AD1870077C042 /* ViewControllers */,
+			);
+			path = MyPage;
+			sourceTree = "<group>";
+		};
+		0A26EDD1280AD1870077C042 /* ViewControllers */ = {
+			isa = PBXGroup;
+			children = (
+				0A26EDD3280AD19C0077C042 /* MyPageViewController.swift */,
+			);
+			path = ViewControllers;
+			sourceTree = "<group>";
+		};
+		0A26EDD2280AD18F0077C042 /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				0A26EDD5280AD1A30077C042 /* InterfaceBuilders */,
+			);
+			path = Views;
+			sourceTree = "<group>";
+		};
+		0A26EDD5280AD1A30077C042 /* InterfaceBuilders */ = {
+			isa = PBXGroup;
+			children = (
+				0A26EDD6280AD1B10077C042 /* MyPage.storyboard */,
+			);
+			path = InterfaceBuilders;
+			sourceTree = "<group>";
+		};
 		0A8DE82427F0489C00077DC6 /* TabBar */ = {
 			isa = PBXGroup;
 			children = (
@@ -216,7 +253,7 @@
 		3AADB25227EF53ED00AFDE01 /* Scenes */ = {
 			isa = PBXGroup;
 			children = (
-                0AB1028027F746D800030C06 /* MyPage */,
+				0A26EDD0280AD1800077C042 /* MyPage */,
 				3AB61E0127F8960F00A30449 /* MoyeorunRoom */,
 				0A8DE82427F0489C00077DC6 /* TabBar */,
 				0A8DE82C27F04D9A00077DC6 /* HomeTab */,
@@ -454,6 +491,7 @@
 				0A8DE82B27F04CC900077DC6 /* TabBar.storyboard in Resources */,
 				0AF2314427F0650000574776 /* HomeTabNowPopular1.png in Resources */,
 				0AF2314327F0650000574776 /* HomeTabNowPopular0.png in Resources */,
+				0A26EDD7280AD1B10077C042 /* MyPage.storyboard in Resources */,
 				0A8DE83C27F0518D00077DC6 /* 모여런 심볼.png in Resources */,
 				0AF2315027F0650B00574776 /* HomeTabNewMission1.png in Resources */,
 				F7CDF8EB27F5E9C1005F03A7 /* MakeRoom.storyboard in Resources */,
@@ -532,6 +570,7 @@
 				0A95B92B27F3564300E131E6 /* HomeTabNewMissionContainer.swift in Sources */,
 				0A95B92927F3563100E131E6 /* HomeTabNowPopularContainer.swift in Sources */,
 				F75E9F9C27E9470100000DCD /* SceneDelegate.swift in Sources */,
+				0A26EDD4280AD19C0077C042 /* MyPageViewController.swift in Sources */,
 				0A8DE84027F052C000077DC6 /* HomeTabViewController.swift in Sources */,
 				F75E9FA427E9470100000DCD /* MoyeoRun.xcdatamodeld in Sources */,
 				0A8DE83327F04EB100077DC6 /* TabBarViewController.swift in Sources */,


### PR DESCRIPTION
## 설명
login figma 14 브랜치 머지 후 pbx파일 오류로  MyPage 그룹이 인식되지 않는 오류를 해결하였습니다.

## 작업 내용
그룹 삭제 후 수동으로 그룹을 만들고 파일 집어 넣었습니다.

## 전달 사항


## 작업 환경
macOS: 12.1
iOS: 

Closes: #43 
