### PR TITLE
fix: PBX파일 에러 해결

### DIFF
--- a/MoyeoRun.xcodeproj/project.pbxproj
+++ b/MoyeoRun.xcodeproj/project.pbxproj
@@ -139,6 +139,8 @@
 				0A26EDD6280AD1B10077C042 /* MyPage.storyboard */,
 			);
 			path = InterfaceBuilders;
+            sourceTree = "<group>";
+        };
 		2049243327F2F3D600CF5A11 /* Components */ = {
 			isa = PBXGroup;
 			children = (


### PR DESCRIPTION
## 설명
충돌 해결할때 잘못 삭제한 내용이 있었나봅니다.

## 작업 내용
pbx 파일 에러 해결

## 전달 사항


## 작업 환경
macOS: 12.1
iOS: 

Closes: #49 
