### PR TITLE
[#70] header 및 refresh 로직 추가

### DIFF
--- a/MoyeoRun.xcodeproj/project.pbxproj
+++ b/MoyeoRun.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		0A75B2B62837364800544AB5 /* RecordTabViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A75B2B52837364800544AB5 /* RecordTabViewController.swift */; };
 		0AA674E528657EB7006A7E72 /* CalendarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AA674E428657EB7006A7E72 /* CalendarViewController.swift */; };
 		0AA674E72866BECD006A7E72 /* RecordTabExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AA674E62866BECD006A7E72 /* RecordTabExtension.swift */; };
+		416E8FEC28B6370500BBA05E /* Interceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 416E8FEB28B6370500BBA05E /* Interceptor.swift */; };
 		5460829649D08B2590F3491A /* Pods_MoyeoRun.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4CCBF5585C20B63EE1C8123D /* Pods_MoyeoRun.framework */; };
 		F74D1F9E2831620A0099B5F0 /* Configuation.swift in Sources */ = {isa = PBXBuildFile; fileRef = F74D1F9B2831620A0099B5F0 /* Configuation.swift */; };
 		F74D1FC1283163030099B5F0 /* SignInDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = F74D1FA6283163030099B5F0 /* SignInDTO.swift */; };
@@ -115,12 +116,13 @@
 		0A75B2B52837364800544AB5 /* RecordTabViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordTabViewController.swift; sourceTree = "<group>"; };
 		0AA674E428657EB7006A7E72 /* CalendarViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarViewController.swift; sourceTree = "<group>"; };
 		0AA674E62866BECD006A7E72 /* RecordTabExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordTabExtension.swift; sourceTree = "<group>"; };
+		416E8FEB28B6370500BBA05E /* Interceptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Interceptor.swift; sourceTree = "<group>"; };
+		416E8FED28B6391900BBA05E /* Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = Configuration/Debug.xcconfig; sourceTree = SOURCE_ROOT; };
+		416E8FEE28B6391900BBA05E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Configuration/Release.xcconfig; sourceTree = SOURCE_ROOT; };
 		4CCBF5585C20B63EE1C8123D /* Pods_MoyeoRun.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MoyeoRun.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		538E40A5DF919EBE4881FE83 /* Pods-MoyeoRun.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MoyeoRun.debug.xcconfig"; path = "Target Support Files/Pods-MoyeoRun/Pods-MoyeoRun.debug.xcconfig"; sourceTree = "<group>"; };
 		ACF6235AE0ADD0047158FA4F /* Pods-MoyeoRun.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MoyeoRun.release.xcconfig"; path = "Target Support Files/Pods-MoyeoRun/Pods-MoyeoRun.release.xcconfig"; sourceTree = "<group>"; };
 		F74D1F9B2831620A0099B5F0 /* Configuation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Configuation.swift; sourceTree = "<group>"; };
-		F74D1FA1283162190099B5F0 /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
-		F74D1FA2283162190099B5F0 /* Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
 		F74D1FA6283163030099B5F0 /* SignInDTO.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SignInDTO.swift; sourceTree = "<group>"; };
 		F74D1FA7283163030099B5F0 /* RefreshDTO.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RefreshDTO.swift; sourceTree = "<group>"; };
 		F74D1FA8283163030099B5F0 /* LogoutDTO.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LogoutDTO.swift; sourceTree = "<group>"; };
@@ -300,8 +302,8 @@
 			isa = PBXGroup;
 			children = (
 				F74D1F9B2831620A0099B5F0 /* Configuation.swift */,
-				F74D1FA2283162190099B5F0 /* Debug.xcconfig */,
-				F74D1FA1283162190099B5F0 /* Release.xcconfig */,
+				416E8FED28B6391900BBA05E /* Debug.xcconfig */,
+				416E8FEE28B6391900BBA05E /* Release.xcconfig */,
 			);
 			name = Configuration;
 			path = MoyeoRun/Configuration;
@@ -406,6 +408,7 @@
 				F74D1FBA283163030099B5F0 /* Response.swift */,
 				F74D1FBB283163030099B5F0 /* MoyaProvider+.swift */,
 				F74D1FBC283163030099B5F0 /* TargetType+.swift */,
+				416E8FEB28B6370500BBA05E /* Interceptor.swift */,
 			);
 			path = Network;
 			sourceTree = "<group>";
@@ -1041,6 +1044,7 @@
 				F74D20322831630C0099B5F0 /* InsertUserInfoViewController.swift in Sources */,
 				F74D202B2831630C0099B5F0 /* RunningContentCell.swift in Sources */,
 				F74D20282831630C0099B5F0 /* MyPageViewController.swift in Sources */,
+				416E8FEC28B6370500BBA05E /* Interceptor.swift in Sources */,
 				0A75B2B62837364800544AB5 /* RecordTabViewController.swift in Sources */,
 				F74D1FCD283163030099B5F0 /* Response.swift in Sources */,
 				F74D206B283163160099B5F0 /* MapKitView.swift in Sources */,
@@ -1108,7 +1112,7 @@
 /* Begin XCBuildConfiguration section */
 		F75E9FAB27E9470200000DCD /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = F74D1FA2283162190099B5F0 /* Debug.xcconfig */;
+			baseConfigurationReference = 416E8FED28B6391900BBA05E /* Debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -1170,7 +1174,7 @@
 		};
 		F75E9FAC27E9470200000DCD /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = F74D1FA1283162190099B5F0 /* Release.xcconfig */;
+			baseConfigurationReference = 416E8FEE28B6391900BBA05E /* Release.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -1226,7 +1230,7 @@
 		};
 		F75E9FAE27E9470200000DCD /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = F74D1FA2283162190099B5F0 /* Debug.xcconfig */;
+			baseConfigurationReference = 416E8FED28B6391900BBA05E /* Debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -1256,7 +1260,7 @@
 		};
 		F75E9FAF27E9470200000DCD /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = F74D1FA1283162190099B5F0 /* Release.xcconfig */;
+			baseConfigurationReference = 416E8FED28B6391900BBA05E /* Debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;

--- a/MoyeoRun/Data/Auth/DTO/RefreshDTO.swift
+++ b/MoyeoRun/Data/Auth/DTO/RefreshDTO.swift
@@ -7,7 +7,9 @@
 
 import Foundation
 
-typealias RefreshRequest = TokenDTO
+struct RefreshRequest: Codable {
+    let refreshToken: String
+}
 
 struct RefreshResponse: Codable {
     let accessToken: String

--- a/MoyeoRun/Data/Auth/DataSource/AuthLocalDataSource.swift
+++ b/MoyeoRun/Data/Auth/DataSource/AuthLocalDataSource.swift
@@ -10,11 +10,15 @@ import Foundation
 protocol AuthLocalDataSourceable: AnyObject {
     init(store: KeychainStorable)
 
+    func getAccessToken() -> Result<String, Error>
+
+    func getRefreshToken() -> Result<String, Error>
+
     @discardableResult
     func storeToken(token: TokenDTO) -> Result<Void, Error>
 
     @discardableResult
-    func refreshToken(token: TokenDTO) -> Result<Void, Error>
+    func refreshAccessToken(accessToken: String) -> Result<Void, Error>
 
     @discardableResult
     func clearToken() -> Result<Void, Error>
@@ -32,6 +36,24 @@ final class AuthLocalDataSource: AuthLocalDataSourceable {
         self.store = store
     }
 
+    func getAccessToken() -> Result<String, Error> {
+        do {
+            let accessToken: String = try store.read(forKey: AuthKey.accessToken)
+            return .success(accessToken)
+        } catch {
+            return .failure(error)
+        }
+    }
+
+    func getRefreshToken() -> Result<String, Error> {
+        do {
+            let refreshToken: String = try store.read(forKey: AuthKey.refreshToken)
+            return .success(refreshToken)
+        } catch {
+            return .failure(error)
+        }
+    }
+
     func storeToken(token: TokenDTO) -> Result<Void, Error> {
         do {
             try store.create(value: token.accessToken, forKey: AuthKey.accessToken)
@@ -42,10 +64,9 @@ final class AuthLocalDataSource: AuthLocalDataSourceable {
         }
     }
 
-    func refreshToken(token: TokenDTO) -> Result<Void, Error> {
+    func refreshAccessToken(accessToken: String) -> Result<Void, Error> {
         do {
-            try store.update(value: token.accessToken, forKey: AuthKey.accessToken)
-            try store.update(value: token.refreshToken, forKey: AuthKey.refreshToken)
+            try store.update(value: accessToken, forKey: AuthKey.accessToken)
             return .success(())
         } catch {
             return .failure(error)

--- a/MoyeoRun/Data/Auth/DataSource/AuthRemoteDataSource.swift
+++ b/MoyeoRun/Data/Auth/DataSource/AuthRemoteDataSource.swift
@@ -35,7 +35,7 @@ protocol AuthRemoteDataSourceable: AnyObject {
 final class AuthRemoteDataSource: AuthRemoteDataSourceable {
     let provider: MoyaProvider<AuthAPI>
 
-    required init(provider: MoyaProvider<AuthAPI> = .init()) {
+    required init(provider: MoyaProvider<AuthAPI> = .init(session: .init(interceptor: Interceptor()))) {
         self.provider = provider
     }
 
@@ -106,17 +106,15 @@ extension AuthAPI: TargetType {
             return .requestJSONEncodable(request)
         case let .refresh(request):
             return .requestJSONEncodable(request)
-        case .logout:
-            return .requestPlain
+        case let .logout(request):
+            return .requestJSONEncodable(request)
         }
     }
 
     var headers: [String: String]? {
         switch self {
-        case .signIn, .signUp, .refresh:
+        case .signIn, .signUp, .refresh, .logout:
             return nil
-        case let .logout(request):
-            return ["Authorization": "Bearer " + request.accessToken]
         }
     }
 }

--- a/MoyeoRun/Data/Base/Network/Interceptor.swift
+++ b/MoyeoRun/Data/Base/Network/Interceptor.swift
@@ -1,0 +1,70 @@
+//
+//  Interceptor.swift
+//  MoyeoRun
+//
+//  Created by Jeongho Moon on 2022/08/24.
+//
+
+import Alamofire
+
+class Interceptor: RequestInterceptor {
+    let repository: AuthRepositable
+
+    private let retryLimit = 3
+    private let retryDelay: TimeInterval = 5
+
+    init(repository: AuthRepositable = AuthRepository()) {
+        self.repository = repository
+    }
+
+    func adapt(
+        _ urlRequest: URLRequest,
+        for session: Session,
+        completion: @escaping (Result<URLRequest, Error>) -> Void
+    ) {
+        var urlRequest = urlRequest
+
+        repository.getAccessToken { result in
+            if case let .success(accessToken) = result {
+                urlRequest.headers.add(.authorization(bearerToken: accessToken))
+            }
+        }
+
+        completion(.success(urlRequest))
+    }
+
+    func retry(
+        _ request: Request,
+        for session: Session,
+        dueTo error: Error,
+        completion: @escaping (RetryResult) -> Void
+    ) {
+        guard request.retryCount <= retryLimit else {
+            return completion(.doNotRetryWithError(error))
+        }
+
+        if request.response?.statusCode == 401 {
+            AuthRepository().refreshToken { result in
+                switch result {
+                case .success:
+                    completion(.doNotRetry)
+                case .failure:
+                    AuthRepository().logout { _ in }
+                }
+            }
+        } else {
+            NetworkReachabilityManager()?.startListening { [weak self] status in
+                guard let retryDelay = self?.retryDelay else {
+                    return completion(.doNotRetryWithError(error))
+                }
+
+                switch status {
+                case .reachable:
+                    completion(.retry)
+                case .notReachable, .unknown:
+                    completion(.retryWithDelay(retryDelay))
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 설명
Alamofire의 Interceptor 기능을 이용하여 adapt, retry 기능을 추가하였습니다.

## 작업 내용
authRepository, authLocalRepository, authRemoteRepository에 관련 기능 추가

## 전달 사항
moya에서 alamofire 기능을 이용하는 방법이 있어서 라이브러리 변경 없이 해당 기능 사용하였습니다.

## 작업 환경
macOS: 
iOS: 

Closes: #70
